### PR TITLE
Add Tapglue user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,9 @@ Versatile authentication API that allows you to integrate logins, social sign in
 Twitter's mobile-first sign in solution. Allows users to easily sign in and sign up using their phone number, manages the user graph, and free for unlimited users. 
 (*[discussion](https://github.com/relatedcode/ParseAlternatives/issues/220)*)
 
+- **[Tapglue](https://www.tapglue.com)**
+Tapglue provides a social layer including user-management for app developers. You can signup and login users, create social graphs (friend & follower model) and build feeds on top of it.
+
 - **[Stormpath](https://stormpath.com)**
 Identity layer for your apps with integrations for popular backend frameworks and user databases. Easily manage user permissions, API keys, and user tokens. 
 (*[discussion](https://github.com/relatedcode/ParseAlternatives/issues/219)*)


### PR DESCRIPTION
Since you extended the sections, I believe it fits in here as you can use Tapglue as a user-management for apps and build up user graphs.

Check the [Docs](https://developers.tapglue.com/docs/users) for more context.